### PR TITLE
cache: Use correct env var according to doc

### DIFF
--- a/jolt/cache.py
+++ b/jolt/cache.py
@@ -1275,7 +1275,7 @@ class ArtifactCache(StorageProvider):
 
         # Read configuration
         self._max_size = config.getsize(
-            "jolt", "cachesize", os.environ.get("JOLT_CACHESIZE", 1 * 1024 ** 3))
+            "jolt", "cachesize", os.environ.get("JOLT_CACHE_SIZE", 1 * 1024 ** 3))
 
         # Create cache directory
         self._fs_create_cachedir()


### PR DESCRIPTION
Should be JOLT_CACHE_SIZE and not JOLT_CACHESIZE