### PR TITLE
cmd: Use SIGTERM instead of SIGINT to kill process

### DIFF
--- a/services/pkg/utils/command_linux.go
+++ b/services/pkg/utils/command_linux.go
@@ -35,7 +35,7 @@ func (c *Command) WaitChild() error {
 }
 
 func (c *Command) Interrupt() error {
-	return c.Process().Signal(os.Interrupt)
+	return c.Process().Signal(syscall.SIGTERM)
 }
 
 func (c *Command) SetStderr(w io.Writer) {


### PR DESCRIPTION
We see a lot of hanging executors after the worker has sent a SIGINT. Killing the executor with SIGTERM seems to always terminate it properly