### PR TITLE
docs: require 0.20 of fasteners

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 bz2file
 colorama
-fasteners
+fasteners==0.20
 ninja
 protobuf
 psutil


### PR DESCRIPTION
Could possibly solve the problem with hanging tasks when waiting for artifact locks to be released.